### PR TITLE
 Noves subrutines min_img_2, apply_pbc

### DIFF
--- a/pbc.f90
+++ b/pbc.f90
@@ -1,8 +1,9 @@
 module pbc
+  use parameters
   contains
  ! ---------------------------------------------------- Minimum image search -----------------------------------------------------------  
   subroutine min_img(x,y,z,a,b,c,dist,L,v)
-    ! finds the closets image of a particle further from L/2 applying PBC
+    ! finds the closest image of a particle further from L/2 applying PBC
     ! x,y,z are the coordinates of the fixed particle
     ! a,b,c are the coordinates of the of the particle whose image to find
     ! dist is the distance between them
@@ -53,4 +54,47 @@ module pbc
     endif
     return
   end subroutine min_img
+  
+  
+  subroutine min_img_2(distv)
+  ! Subrutina adaptada al calcul de forces (subroutine compute_LJ_force)
+        implicit none
+        real(8), dimension(D), intent(inout) :: distv
+        integer i
+        do i=1,D
+              if(distv(i).gt.(L/2d0)) distv(i) = distv(i) - L
+              if(distv(i).lt.(-L/2d0)) distv(i) = distv(i) + L
+        enddo
+  end subroutine min_img_2
+            
+  		    
+  
+  ! ---------------------------------------------------- PBC -----------------------------------------------------------------------
+  subroutine apply_pbc(pos)
+    ! applies pbc to the position matrix once the positions are updated in the integration algorithm
+    implicit none
+    real(8), dimension(D,N), intent(inout) :: pos
+    integer i, j, factor
+    real(8) :: lower_bound, upper_bound
+    
+    ! Parametres de la caixa de simulacio:
+    lower_bound = 0d0
+    upper_bound = L
+  
+    ! Check if the particle has scaped the simulation box, and if so apply PBC:
+    do i = 1,N
+      do j = 1,D
+        if(pos(j,i).gt.upper_bound) then
+          ! how much greater? : factor
+          factor = int(pos(j,i)/L)
+          pos(j,i) = pos(j,i) - factor*L
+        endif
+        if(pos(j,i).lt.lower_bound) then
+          ! how much lower? : factor
+          factor = int(dabs(pos(j,i))/L)
+          pos(j,i) = pos(j,i) + (factor+1)*L
+        endif
+      enddo
+    enddo
+  end subroutine apply_pbc
 end module


### PR DESCRIPTION
Nova subrutina min_img_2 adaptada a integraforces.f90
Subrutina més simple per fer min image convention. Hi havia molts passos innecessaris a min_img per trobar la posició de la       imatge, que realment no és necessària.

Nova subrutina apply_pbc per fer servir al integrar posicions. 
Un cop actualitzades les posicions, per exemple a la rutina de velocity Verlet, es pot cridar aquest subrutina per tornar a posar a la caixa una particula que n'hagi escapat aplicant PBC.