### PR TITLE
Afegeixo un modul per la g(r) + addicions a vvel_solver

### DIFF
--- a/integraforces.f90
+++ b/integraforces.f90
@@ -176,6 +176,7 @@
                  write(eunit_g,*) (j-1)*grid_shells, rad_distr(j)
                enddo
                write(eunit_g,*) ! separation line
+               
             enddo
 
             return

--- a/integraforces.f90
+++ b/integraforces.f90
@@ -135,12 +135,18 @@
          subroutine vvel_solver(Nt,dt,r,v,Temp,eunit) !Nt -- n_total?
    !     Performs Nt steps of the velocity verlet algorithm while computing
    !     different observables and writing to file.
+            use radial_distribution
             implicit none
             integer, intent(in) :: Nt, eunit
             real(8) :: dt, Temp
             real(8) :: r(D,N), v(D,N), f(D,N)
             real(8) :: ekin, U, t, Tins, Ppot, Ptot
-            integer :: i,j
+            integer :: i,j,Nshells,eunit_g
+            
+            ! Initialization of the g(r) calculation:
+            Nshells = 100
+            call prepare_shells(Nshells)
+            eunit_g = 2*eunit ! Solucio temporal
 
             t = 0.d0
             call compute_force_LJ(r,f,U,Ppot) !Initial force, energy and pressure
@@ -160,9 +166,16 @@
                call compute_force_LJ(r,f,U,Ppot)
                call energy_kin(v,ekin,Tins)
                Ptot = rho*Tins + Ppot
+               call rad_distr_fun(r)
 
                !Write to file.
                write(eunit,*) t, ekin, U, ekin+U, Tins, sum(v,2)
+               
+               !Write snapshot of g(r)
+               do j=1,Nshells
+                 write(eunit_g,*) (j-1)*grid_shells, rad_distr(j)
+               enddo
+               write(eunit_g,*) ! separation line
             enddo
 
             return

--- a/rad_dist.f90
+++ b/rad_dist.f90
@@ -1,0 +1,59 @@
+module radial_distribution
+  real(8), parameter :: pi = 4d0*datan(1d0)
+  ! grid_shells will save the width of the spherical shells:
+  real(8) :: grid_shells
+  ! rad_distr will save the number of particles on each shell
+  ! shells_vect will save the volume of each spherical shell
+  real(8), dimension(:), allocatable :: rad_distr, shells_vect
+  contains
+    
+    subroutine prepare_shells(Nshells)
+      ! Given the number of shells desired, this subrutine has to be called right before starting the simulation.
+      ! Computes/allocates the varialbes declared in the module that will be used in the computation of g(r)
+      use parameters, only : L, rho
+      implicit none
+      integer, intent(in) :: Nshells
+      integer i
+      allocate(rad_distr(Nshells))
+      allocate(rad_distr(Nshells))
+      ! Define the grid parameter:
+      grid_shells = L/(2*dble(Nshells))
+      ! Compute volume of each shell:
+      do i=1,Nshells
+        shells_vect(i) = 4d0*pi/3d0 * grid_shells**3 * rho * (i**3 - (i-1)**3)
+      enddo
+   end subroutine prepare_shells
+   
+   
+   subroutine rad_distr_fun(pos)
+    ! computes g(r) in a histogram-like way, saving it in the defined rad_distr array
+    ! pass the shell volumes * density in a vector to avoid calculating them every time! (denominator, g = N/(dens*V))
+    use parameters, only : N,L,D
+    implicit none
+    real(8), intent(in) :: pos(D,N)
+    ! internal:
+    integer i,j,k
+    real(8) dist,distv,inner_radius,outer_radius
+    
+    ! Compute the radial distribution function by averaging the r.d.f. over all particles.
+    do i=1,N
+      do j=1,N
+        if(i.ne.j) then
+          ! Check in wich cell particle j falls repsective from particle i:
+          distv = pos(:,i) - pos(:,j)
+          call min_img_2(distv)
+          dist = sqrt(sum((distv)**2))
+          do k=1,Nshells
+            outer_radius = k*grid_space
+            inner_radius = (k-1)*grid_space
+            if(dist.lt.outer_radius.and.dist.gt.inner_radius) then
+              g(k) = g(k) + (1d0/shell_vols(k))/dble(N) ! normalize to the number of particles, divide by N
+            endif
+          enddo
+        endif
+      enddo
+    enddo
+    
+    return
+  end subroutine rad_distr_fun
+  

--- a/rad_dist.f90
+++ b/rad_dist.f90
@@ -15,7 +15,7 @@ module radial_distribution
       integer, intent(in) :: Nshells
       integer i
       allocate(rad_distr(Nshells))
-      allocate(rad_distr(Nshells))
+      allocate(shells_vect(Nshells))
       ! Define the grid parameter:
       grid_shells = L/(2*dble(Nshells))
       ! Compute volume of each shell:
@@ -35,6 +35,7 @@ module radial_distribution
     integer i,j,k
     real(8) dist,distv,inner_radius,outer_radius
     
+    rad_distr = 0d0
     ! Compute the radial distribution function by averaging the r.d.f. over all particles.
     do i=1,N
       do j=1,N


### PR DESCRIPTION
Mòdul per calcular g(r), defineixo les variables adecuades i una subrutina per inicialitzar-les i fer allocates, per cridar quan comença la simulació. 
He afegit codi a vvel_solver per que fagi el necessari per calcular g(r) a cada pas: initcialització de les variables de g(r),
un call a la subrutina per calcular-la i escriptura a fitxer dins del bucle.

De moment només s'escriu en un fitxer la 'foto' de la g(r) a cada pas, i l'anàlisi estadístic es faria al final, llegint del fitxer i promitjant cada caixa de la g(r) per tots els passos. Es podria afegir alguna manera d'anar calculant el promig final cada cop que es calcula la g(r) i estalviar l'escriptura a cada pas.