### PR TITLE
g(r) addapted to imin, imax. New particle distribution specific for nested loop + another g(r) routine that uses it

### DIFF
--- a/parallel/init.f90
+++ b/parallel/init.f90
@@ -97,17 +97,12 @@ module init
                  endif
               enddo limits
            enddo
-         
-          ! Check lines below: could be erased  
-          !do i=1,numproc
-          !   print*, "Limits for proc ",i,":", ranges_proc(i,:), "Num paris: ",sum(num_pairs(ranges_proc(i,1):ranges_proc(i,2)))
-          !enddo
-          ! End check lines
           
           ! Finally, assignate the min and max index to the global variables:
           imin_p = ranges_proc(taskid+1,1)
           imax_p = ranges_proc(taskid+1,2)
           !print*, "task ",taskid, " with particle ranges ", imin_p, imax_p
+          deallocate(ranges_proc)
        end subroutine divide_particles_pairs
 
         subroutine init_sc_gather(pos)

--- a/parallel/main.f90
+++ b/parallel/main.f90
@@ -65,14 +65,24 @@ program main
       call verlet_v_step(pos,vel,time,i,dt_sim,epot,P)
     enddo
  
-    !Start g(r) test
+    ! Start g(r) test: david: torno a cridar init_sc perque amb 2 processadors el resultat de verlet em dona problemes
+    call init_sc_gather(pos)
     Nshells = 100
-    call prepare_shells_and_procs(Nshells,numproc)
-    call rad_distr_fun(pos,Nshells)
+    call prepare_shells(Nshells)
+    call rad_dist_fun(pos,Nshells)
+    
+    ! BARRIER FOR TESTING
+    !call sleep(floor(2d0))
+    !call MPI_BARRIER(MPI_COMM_WORLD,ierror)
+    
+    call divide_particles_pairs()
+    call rad_dist_fun_pairs(pos,Nshells)
     if(taskid == master) then
         open(11, file="results/radial_distribution.dat")
+        open(111, file="results/radial_distribution_pairs.dat")
         do i=1,Nshells
             write(11,*) (i-1)*grid_shells+grid_shells/2d0,g(i)
+            write(111,*) (i-1)*grid_shells+grid_shells/2d0,g_p(i)
         enddo
     endif
     call deallocate_g_variables()

--- a/parallel/parameters.f90
+++ b/parallel/parameters.f90
@@ -16,6 +16,9 @@
       integer,parameter    :: master=0
       integer              :: imin,imax,local_size
       integer, allocatable :: aux_size(:), aux_pos(:)
+      
+      ! Other parallel params (testing)
+      integer :: imin_p, imax_p
 
       contains
 

--- a/parallel/rad_dist.f90
+++ b/parallel/rad_dist.f90
@@ -2,30 +2,30 @@
 
 module rad_dist
   real(8), parameter :: pi = 4d0*datan(1d0)
-  ! grid_shells will save the width of the spherical shells:
   real(8) :: grid_shells
+  real(8), dimension(:), allocatable :: g, shells_vect
+  ! this is for testing purposes only:
+  real(8), dimension(:), allocatable :: g_p
+  
+  ! module variables info:
+  ! grid_shells will save the width of the spherical shells:
   ! g will save the actual radial distr function, g = N/(dens*V))
   ! shells_vect will save the volume*density of each spherical shell, to avoid computing it at every call of rad_distr_fun
-  real(8), dimension(:), allocatable :: g, shells_vect
-  integer, dimension(:,:), allocatable :: ranges_proc
   contains
-    
-    subroutine prepare_shells_and_procs(Nshells,avail_proc)
-      ! Given the number of shells desired, this subrutine has to be called right before starting the simulation.
-      ! Computes/allocates the varialbes declared in the module that will be used in the computation of g(r).
-      ! Sets the particle range that each processor has to compute
-      ! INPUT:
-      !      Nshells:    number of bins where g(r) will be computed
-      !      avail_proc:  number of available processors
-      ! OUTPUT: (module variable)
-      !      shells_vect:    holds the volume*density product of each sperical shell
-      use parameters, only : N, L, numproc
+  
+  subroutine prepare_shells(Nshells)
+     ! Given the number of shells desired, this subrutine has to be called right before starting the simulation.
+     ! Computes/allocates the varialbes declared in the module that will be used in the computation of g(r).
+     ! INPUT: --------------------------------------------------------------------------
+     !      Nshells:    number of bins where g(r) will be computed
+     ! OUTPUT: (module variable) -------------------------------------------------------
+     !      shells_vect:    holds the volume*density product of each sperical shell
+      use parameters, only : L
       implicit none
-      integer, intent(in) :: Nshells, avail_proc
-      integer i,j
-      real(8) total_pairs, pairs_per_proc, sum_pairs
-      real(8), dimension(N) :: num_pairs
+      integer, intent(in) :: Nshells
+      integer i
       allocate(g(Nshells))
+      allocate(g_p(Nshells))
       allocate(shells_vect(Nshells))
       ! Define the grid parameter:
       grid_shells = (L/2d0)/(dble(Nshells))
@@ -33,41 +33,17 @@ module rad_dist
       do i=1,Nshells
           shells_vect(i) = 4d0*pi/3d0 * grid_shells**3 * (i**3 - (i-1)**3)
       enddo
-      ! Distribute particles bewteen processors (aprox equal number per processor):
-      do i=1,N
-          num_pairs(i) = N-i
-      enddo
-      allocate(ranges_proc(avail_proc,2))
-      total_pairs = sum(dble(num_pairs))
-      pairs_per_proc = total_pairs/dble(numproc)
-      ranges_proc(1,1) = 1
-      ranges_proc(numproc,2) = N-1
-      do i=1,numproc-1
-          sum_pairs = 0d0
-          limits: do j=ranges_proc(i,1),N
-              sum_pairs = sum_pairs + dble(num_pairs(j))
-              if(sum_pairs.gt.pairs_per_proc) then
-                  ranges_proc(i,2) = j
-                  ranges_proc(i+1,1) = j+1
-                  exit limits
-              endif
-          enddo limits
-      enddo
-    ! Check lines below: could be erased  
-    ! do i=1,numproc
-    !     print*, "Limits for proc ",i,":", ranges_proc(i,:), "Num paris: ",sum(num_pairs(ranges_proc(i,1):ranges_proc(i,2)))
-    ! enddo
-   end subroutine prepare_shells_and_procs
+   end subroutine prepare_shells
    
-   subroutine rad_distr_fun(pos,Nshells)
+ subroutine rad_dist_fun(pos,Nshells)
     ! computes g(r) in a histogram-like way, saving it in the defined g array
     ! uses the module variable shells_vect
-    ! INPUT:
+    ! INPUT: ----------------------------------------------------------------------------
     !      pos:    position matrix of the particles
     !      Nshells:    number of bins where to compute g
-    ! OUTPUT: (module variable)
+    ! OUTPUT: (module variable) ---------------------------------------------------------
     !      g:    radial distribution function
-    use parameters, only : N,L,D,rho,numproc,taskid,master
+    use parameters
     use pbc
     implicit none
     include 'mpif.h'
@@ -82,48 +58,108 @@ module rad_dist
     real(8), dimension(Nshells) :: glocal
     
     g = 0d0
-    part_ini = ranges_proc(taskid+1,1)
-    part_end = ranges_proc(taskid+1,2)
+    glocal = 0d0
     pos_local = pos
-    ! Cast the position vector to all processors:
-    do i=1,3
-        coord = pos_local(i,:)
-        call MPI_BCAST(coord,N,MPI_DOUBLE_PRECISION,master,MPI_COMM_WORLD,request,ierror)
-        pos_local(i,:) = coord
-    enddo
-    ! Compute the radial distribution function by averaging the r.d.f. over all particles.
-    do i=part_ini,part_end
-        do j=i+1,N
-            if(i.ne.j) then
-                ! Check in wich cell particle j falls repsective from particle i:
-                distv = pos(:,i) - pos(:,j)
-                call min_img_2(distv)
-                dist = sqrt(sum((distv)**2))
-                ! Given dist, add contribution to g(r):
-                do k=1,Nshells
-                    outer_radius = k*grid_shells
-                    inner_radius = (k-1)*grid_shells
-                    if(dist.lt.outer_radius.and.dist.gt.inner_radius) then
-                        glocal(k) = glocal(k) + 1d0/(rho * shells_vect(k))
-                    endif
-                enddo
-            endif
-         enddo
-    enddo
-    g = 2d0*g/dble(N)    
-    call MPI_BARRIER(MPI_COMM_WORLD,ierror)
-    ! Check lines below:
-    !print*, "taskid ",taskid," g local 20 30 40", glocal(20), glocal(30), glocal(40)
-    !print*, "taskid",taskid,"g",glocal(:)
     
+    do i=1,3
+       coord = pos_local(i,:)
+       call MPI_BCAST(coord,N,MPI_DOUBLE_PRECISION,master,MPI_COMM_WORLD,request,ierror)
+       pos_local(i,:) = coord
+    enddo
+    
+    ! test lines:
+    !print*, " about to start g(r) loop, task ", taskid,", ranges: ", imin, imax
+    !print*, " is ther something in positions? ", pos_local(1,1), pos_local(2,1), pos_local(3,1)
+    
+    do i=imin,imax
+       do j=1,N
+          if(j.ne.i) then
+             distv = pos_local(:,i) - pos_local(:,j)
+             call min_img_2(distv)
+             dist = dsqrt(sum((distv)**2))
+             do k=1,Nshells
+                outer_radius = k*grid_shells
+                inner_radius = (k-1)*grid_shells
+                if(dist.lt.outer_radius.and.dist.gt.inner_radius) then
+                   glocal(k) = glocal(k) + 1d0/(rho * shells_vect(k))
+                endif
+             enddo
+          endif
+       enddo
+    enddo
+    call MPI_BARRIER(MPI_COMM_WORLD,ierror)
+    !print*, "Task", taskid, " g(40) ", glocal(40)
     call MPI_REDUCE(glocal,g,Nshells,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_WORLD,ierror)
-  end subroutine rad_distr_fun
-  
+    ! and normalize for N particles
+    if(taskid.eq.master) g = g/dble(N)
+ end subroutine rad_dist_fun
+ 
+ 
+ subroutine rad_dist_fun_pairs(pos,Nshells)
+ ! THIS ONE USES imin_p,imax_p to use j=i+1,N in the nested loop !
+ ! computes g(r) in a histogram-like way, saving it in the defined g array
+    ! uses the module variable shells_vect
+    ! INPUT: ----------------------------------------------------------------------------
+    !      pos:    position matrix of the particles
+    !      Nshells:    number of bins where to compute g
+    ! OUTPUT: (module variable) ---------------------------------------------------------
+    !      g:    radial distribution function
+    use parameters
+    use pbc
+    implicit none
+    include 'mpif.h'
+    integer, intent(in) :: Nshells
+    real(8), intent(in) :: pos(D,N)
+    ! internal:
+    integer i,j,k,part_ini,part_end,ierror,request
+    real(8) dist,inner_radius,outer_radius
+    real(8), dimension(D) :: distv(D)
+    real(8), dimension(N) :: coord
+    real(8), dimension(D,N) :: pos_local
+    real(8), dimension(Nshells) :: glocal
+    
+    g_p = 0d0
+    glocal = 0d0
+    pos_local = pos
+    
+    do i=1,3
+       if(taskid.eq.master) coord = pos_local(i,:)
+       call MPI_BCAST(coord,N,MPI_DOUBLE_PRECISION,master,MPI_COMM_WORLD,request,ierror)
+       pos_local(i,:) = coord
+    enddo
+    
+
+    ! test lines:
+    !print*, " about to start g(r) loop (pairs), task ", taskid,", ranges: ", imin_p, imax_p
+    !print*, " is ther something in positions? ", pos_local(1,1), pos_local(2,1), pos_local(3,1)
+    
+    ! Nested loop for i,j pairs only
+    do i=imin_p,imax_p
+       do j=i+1,N
+          distv = pos_local(:,i) - pos_local(:,j)
+          call min_img_2(distv)
+          dist = dsqrt(sum((distv)**2))
+          do k=1,Nshells
+             outer_radius = k*grid_shells
+             inner_radius = (k-1)*grid_shells
+             if(dist.lt.outer_radius.and.dist.gt.inner_radius) then
+                glocal(k) = glocal(k) + 1d0/(rho * shells_vect(k))
+             endif
+          enddo
+       enddo
+    enddo
+    !print*, "Task", taskid, " g(40) ", glocal(40)
+    call MPI_BARRIER(MPI_COMM_WORLD,ierror)
+    call MPI_REDUCE(glocal,g_p,Nshells,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_WORLD,ierror)
+    ! Add the duplicated contribution left by not counting the j,i pairs in the nested loop, normalize for N particles
+    if(taskid.eq.master) g_p = 2d0*g_p/dble(N)
+ end subroutine rad_dist_fun_pairs
+ 
+
   subroutine deallocate_g_variables()
   ! Deallocate arrays used for computing g. Called before program end.
     deallocate(g)
     deallocate(shells_vect)
   end subroutine
 
-end module rad_dist
-  
+end module rad_dist      


### PR DESCRIPTION
He afegit a init una subrutina divide_particles_pairs per dividir els rangs de particules que calcula cada processador en funcio de les parelles que ha de fer de manera que no es fagi un double counting. Serien uns rangs per fer servir especificament en bucles:
do i=imin_p,imax_p
  do j=i+1,N

Ara mateix hi ha dues subrutines de g(r), una fent servir imin,imax i una altre fent servir el segon mètode de distribuir els rangs de particules.