### PR TITLE
Clean version of g(r), divide_particles_pairs

### DIFF
--- a/parallel/init.f90
+++ b/parallel/init.f90
@@ -33,7 +33,7 @@ module init
 
             call reduced_units()
             call divide_particles()
-            call divide_particles_pairs_improv()
+            call divide_particles_pairs()
         end subroutine get_param
 
         subroutine divide_particles()
@@ -62,49 +62,8 @@ module init
             end do
             
         end subroutine divide_particles
-        
-        subroutine divide_particles_pairs()
-           ! Author: David March
-           ! Distribute particles so they each processor computes an approx. equal number of pairs in a nested loop such as:
-           ! do i=imin_p,imax_p
-           !    do j=i+1,N
-           ! Sets the particles ranges per processor in imin_p, imax_p
-           implicit none
-           !include 'mpif.h'
-           integer :: i,j
-           integer, dimension(N) :: num_pairs
-           integer, dimension(:,:), allocatable :: ranges_proc
-           real(8) total_pairs, pairs_per_proc, sum_pairs
-           
-           do i=1,N
-              num_pairs(i) = N-i
-           enddo
-           total_pairs = dble(N*(N-1))/dble(2)
-           pairs_per_proc = total_pairs/dble(numproc)
-           
-           allocate(ranges_proc(numproc,2)) ! inferior limit at (:,1), superior at (:,2) for each processor
-           ranges_proc(1,1) = 1
-           ranges_proc(numproc,2) = N-1
-           do i=1,numproc-1
-              sum_pairs = 0d0
-              limits: do j=ranges_proc(i,1),N
-                 sum_pairs = sum_pairs + dble(num_pairs(j))
-                 if(sum_pairs.gt.pairs_per_proc) then
-                    ranges_proc(i,2) = j
-                    ranges_proc(i+1,1) = j+1
-                    exit limits
-                 endif
-              enddo limits
-           enddo
-          
-          ! Finally, assignate the min and max index to the global variables:
-          imin_p = ranges_proc(taskid+1,1)
-          imax_p = ranges_proc(taskid+1,2)
-          !print*, "task ",taskid, " with particle ranges ", imin_p, imax_p
-          deallocate(ranges_proc)
-       end subroutine divide_particles_pairs
-       
-       subroutine divide_particles_pairs_improv()
+              
+       subroutine divide_particles_pairs()
            ! Author: David March
            ! Distribute particles so they each processor computes an approx. equal number of pairs in a nested loop such as:
            ! do i=imin_p,imax_p
@@ -171,29 +130,10 @@ module init
               jmax_p(i) = N
           enddo
           
-          !if(taskid==master) CALL sleep(5)
-          ! CHECK:
-          !write(*,*) "Task", taskid
-          !do i=1,N
-          !    write(*,*) jmin_p(i),jmax_p(i)
-          !enddo
-          
-          ! Prova serie per veure els rangs ben ordenats
-          !if(taskid==master) then
-          !do k=1,numproc
-          !    write(*,'(A17, I2)') "Ranges processor ", k
-          !    write(*,'(A8, 2(I4,1X))') "     i: ", ranges_proc_i(k,1),ranges_proc_i(k,2)
-          !    write(*,'(A21, I5)') "     Pairs assigned: ", track_pairs(k)
-          !    write(*,'(A20, I4, A12, 2(I4,1X))') "          For min i ", ranges_proc_i(k,1), " j range is: ", &
-          !                                                   ranges_proc_j_imin(k,1), ranges_proc_j_imin(k,2)
-          !    write(*,'(A20, I4, A12, 2(I4,1X))') "          For max i ", ranges_proc_i(k,2), " j range is: ", &
-          !                                                   ranges_proc_j_imax(k,1), ranges_proc_j_imax(k,2)
-          !enddo
-          !endif
           deallocate(ranges_proc_i)
           deallocate(ranges_proc_j_imin)
           deallocate(ranges_proc_j_imax)
-       end subroutine divide_particles_pairs_improv
+       end subroutine divide_particles_pairs
 
         subroutine init_sc(pos)
             ! Author: Eloi Sanchez

--- a/parallel/plots.p
+++ b/parallel/plots.p
@@ -59,8 +59,7 @@ set ylabel "Frequència"
 set yrange[0:]
 unset key
 unset offsets
-plot "./results/radial_distribution.dat" u 1:2:3 w yerrorbars lc rgb "light-blue", \
-'' u 1:2 w l lc rgb "blue";
+plot "./results/radial_distribution.dat" u 1:2 w l lc rgb "blue";
 
 set terminal png size 800,600
 system "mkdir -p ./results/plots"

--- a/parallel/rad_dist.f90
+++ b/parallel/rad_dist.f90
@@ -32,7 +32,7 @@ module rad_dist
       enddo
    end subroutine prepare_shells
 
- subroutine rad_dist_fun_pairs_improv(pos,Nshells)
+ subroutine rad_dist_fun(pos,Nshells)
  ! THIS ONE USES i=imin_p,imax_p j=jmin_p(i),jmax_p(i) in the nested loop. Equal number of paris per processor.
  ! computes g(r) in a histogram-like way, saving it in the defined g array
     ! uses the module variable shells_vect
@@ -52,41 +52,25 @@ module rad_dist
     real(8) dist,inner_radius,outer_radius
     real(8), dimension(D) :: distv(D)
     real(8), dimension(N) :: coord
-    real(8), dimension(D,N) :: pos_local
-    real(8), dimension(Nshells) :: glocal
     
-    g = 0d0
-    glocal = 0d0
-    pos_local = pos
-    
-    !do i=1,3
-    !   if(taskid.eq.master) coord = pos_local(i,:)
-    !   call MPI_BCAST(coord,N,MPI_DOUBLE_PRECISION,master,MPI_COMM_WORLD,request,ierror)
-    !   pos_local(i,:) = coord
-    !enddo
-    
+    g = 0d0        
     ! Nested loop for i,j pairs only
     do i=imin_p,imax_p
        do j=jmin_p(i),jmax_p(i)
-          distv = pos_local(:,i) - pos_local(:,j)
+          distv = pos(:,i) - pos(:,j)
           call min_img(distv)
           dist = dsqrt(sum((distv)**2))
           do k=1,Nshells
              outer_radius = k*grid_shells
              inner_radius = (k-1)*grid_shells
              if(dist.lt.outer_radius.and.dist.gt.inner_radius) then
-                glocal(k) = glocal(k) + 1d0/(rho * shells_vect(k))
+                g(k) = g(k) + 1d0/(rho * shells_vect(k))
              endif
           enddo
        enddo
     enddo
-    g = glocal
     g = 2d0*g/dble(N)
-    !call MPI_BARRIER(MPI_COMM_WORLD,ierror)
-    !call MPI_REDUCE(glocal,g,Nshells,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_WORLD,ierror)
-    ! Add the duplicated contribution left by not counting the j,i pairs in the nested loop, normalize for N particles
-    !if(taskid.eq.master) g = 2d0*g/dble(N)
- end subroutine rad_dist_fun_pairs_improv
+ end subroutine rad_dist_fun
  
 
   subroutine deallocate_g_variables()
@@ -94,119 +78,5 @@ module rad_dist
     deallocate(g)
     deallocate(shells_vect)
   end subroutine
-  
-  
-  
-   subroutine rad_dist_fun_pairs(pos,Nshells)  ! LESS EFICIENT, CURRENTLY UNUSED
-    ! THIS ONE USES imin_p,imax_p to use j=i+1,N in the nested loop. Approx (but not equal) same amount of pairs per processor.
-    ! computes g(r) in a histogram-like way, saving it in the defined g array
-    ! uses the module variable shells_vect
-    ! INPUT: ----------------------------------------------------------------------------
-    !      pos:    position matrix of the particles
-    !      Nshells:    number of bins where to compute g
-    ! OUTPUT: (module variable) ---------------------------------------------------------
-    !      g:    radial distribution function
-    use parameters
-    use pbc
-    implicit none
-    include 'mpif.h'
-    integer, intent(in) :: Nshells
-    real(8), intent(in) :: pos(D,N)
-    ! internal:
-    integer i,j,k,part_ini,part_end,ierror,request
-    real(8) dist,inner_radius,outer_radius
-    real(8), dimension(D) :: distv(D)
-    real(8), dimension(N) :: coord
-    real(8), dimension(D,N) :: pos_local
-    real(8), dimension(Nshells) :: glocal
-    
-    g = 0d0
-    glocal = 0d0
-    pos_local = pos
-    
-    do i=1,3
-       if(taskid.eq.master) coord = pos_local(i,:)
-       call MPI_BCAST(coord,N,MPI_DOUBLE_PRECISION,master,MPI_COMM_WORLD,request,ierror)
-       pos_local(i,:) = coord
-    enddo
-    
-    ! Nested loop for i,j pairs only
-    do i=imin_p,imax_p
-       do j=i+1,N
-          distv = pos_local(:,i) - pos_local(:,j)
-          call min_img(distv)
-          dist = dsqrt(sum((distv)**2))
-          do k=1,Nshells
-             outer_radius = k*grid_shells
-             inner_radius = (k-1)*grid_shells
-             if(dist.lt.outer_radius.and.dist.gt.inner_radius) then
-                glocal(k) = glocal(k) + 1d0/(rho * shells_vect(k))
-             endif
-          enddo
-       enddo
-    enddo
-    !print*, "Task", taskid, " g(40) ", glocal(40)
-    call MPI_BARRIER(MPI_COMM_WORLD,ierror)
-    call MPI_REDUCE(glocal,g,Nshells,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_WORLD,ierror)
-    ! Add the duplicated contribution left by not counting the j,i pairs in the nested loop, normalize for N particles
-    if(taskid.eq.master) g = 2d0*g/dble(N)
- end subroutine rad_dist_fun_pairs
- 
- 
-   subroutine rad_dist_fun(pos,Nshells) ! THE LEAST EFFICIENT, CURRENTLY UNUSED.
-    ! USES imin, imax from divide_particles() to divide the work (i.e. each processor with the same amount of particles)
-    ! computes g(r) in a histogram-like way, saving it in the defined g array
-    ! uses the module variable shells_vect
-    ! INPUT: ----------------------------------------------------------------------------
-    !      pos:    position matrix of the particles
-    !      Nshells:    number of bins where to compute g
-    ! OUTPUT: (module variable) ---------------------------------------------------------
-    !      g:    radial distribution function
-    use parameters
-    use pbc
-    implicit none
-    include 'mpif.h'
-    integer, intent(in) :: Nshells
-    real(8), intent(in) :: pos(D,N)
-    ! internal:
-    integer i,j,k,part_ini,part_end,ierror,request
-    real(8) dist,inner_radius,outer_radius
-    real(8), dimension(D) :: distv(D)
-    real(8), dimension(N) :: coord
-    real(8), dimension(D,N) :: pos_local
-    real(8), dimension(Nshells) :: glocal
-    
-    g = 0d0
-    glocal = 0d0
-    pos_local = pos
-    
-    do i=1,3
-       coord = pos_local(i,:)
-       call MPI_BCAST(coord,N,MPI_DOUBLE_PRECISION,master,MPI_COMM_WORLD,request,ierror)
-       pos_local(i,:) = coord
-    enddo
-    
-    do i=imin,imax
-       do j=1,N
-          if(j.ne.i) then
-             distv = pos_local(:,i) - pos_local(:,j)
-             call min_img(distv)
-             dist = dsqrt(sum((distv)**2))
-             do k=1,Nshells
-                outer_radius = k*grid_shells
-                inner_radius = (k-1)*grid_shells
-                if(dist.lt.outer_radius.and.dist.gt.inner_radius) then
-                   glocal(k) = glocal(k) + 1d0/(rho * shells_vect(k))
-                endif
-             enddo
-          endif
-       enddo
-    enddo
-    call MPI_BARRIER(MPI_COMM_WORLD,ierror)
-    !print*, "Task", taskid, " g(40) ", glocal(40)
-    call MPI_REDUCE(glocal,g,Nshells,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_WORLD,ierror)
-    ! and normalize for N particles
-    if(taskid.eq.master) g = g/dble(N)
- end subroutine rad_dist_fun
 
 end module rad_dist      


### PR DESCRIPTION
Trec subrutines de g(r) que feien servir versions menys òptimes de la divisió de partícules. Trec també el divide_particles_pairs antic, i deixo el bò (abans amb el sufix_improv()) com a únic divide_particles. 
La nova manera de calcular la g(r), mantenint cada contribució únicament al processador on es calcula i fent REDUCE al final del programa impedeix calcular g(r)**2, ja que es necessitaria fer un REDUCE per cada càlcul de g(r). Prioritzo l'eficiència en favor de tenir barres d'error a g(r) així que les trec.